### PR TITLE
Remove output format from schema

### DIFF
--- a/INPUT_SCHEMA.json
+++ b/INPUT_SCHEMA.json
@@ -38,14 +38,6 @@
       "minimum": 5,
       "maximum": 300
     },
-    "output_format": {
-      "title": "Output Format",
-      "type": "string",
-      "editor": "textfield",
-      "description": "Format for output data (json, jsonl, csv, xml, parquet)",
-      "enum": ["json", "jsonl", "csv", "xml", "parquet"],
-      "default": "json"
-    },
     "filters": {
       "title": "Product Filters",
       "type": "object",


### PR DESCRIPTION
Remove `output_format` field from `INPUT_SCHEMA.json` to fix a schema validation error.

The `output_format` field was causing a validation error because its `editor` property was set to `"textfield"` while an `enum` property was present, which requires `editor` to be `"select"`. The field was removed as per the user's request.

---
<a href="https://cursor.com/background-agent?bcId=bc-c89344bf-0b45-438b-920f-e9dadd35a5e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c89344bf-0b45-438b-920f-e9dadd35a5e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Bug Fixes:
- Remove `output_format` field from INPUT_SCHEMA.json to resolve schema validation error due to mismatched editor and enum properties.